### PR TITLE
Move current_tenant within each concern module

### DIFF
--- a/lib/acts_as_tenant/controller_extensions.rb
+++ b/lib/acts_as_tenant/controller_extensions.rb
@@ -4,10 +4,6 @@ module ActsAsTenant
     autoload :Subdomain, "acts_as_tenant/controller_extensions/subdomain"
     autoload :SubdomainOrDomain, "acts_as_tenant/controller_extensions/subdomain_or_domain"
 
-    def current_tenant
-      ActsAsTenant.current_tenant
-    end
-
     # this method allows setting the current_tenant by reading the subdomain and looking
     # it up in the tenant-model passed to the method. The method will look for the subdomain
     # in a column referenced by the second argument.

--- a/lib/acts_as_tenant/controller_extensions/filter.rb
+++ b/lib/acts_as_tenant/controller_extensions/filter.rb
@@ -12,6 +12,10 @@ module ActsAsTenant
       def set_current_tenant(current_tenant_object)
         ActsAsTenant.current_tenant = current_tenant_object
       end
+
+      def current_tenant
+        ActsAsTenant.current_tenant
+      end
     end
   end
 end

--- a/lib/acts_as_tenant/controller_extensions/subdomain.rb
+++ b/lib/acts_as_tenant/controller_extensions/subdomain.rb
@@ -16,6 +16,10 @@ module ActsAsTenant
           ActsAsTenant.current_tenant = tenant_class.where(tenant_column => request.subdomains.last.downcase).first
         end
       end
+
+      def current_tenant
+        ActsAsTenant.current_tenant
+      end
     end
   end
 end

--- a/lib/acts_as_tenant/controller_extensions/subdomain_or_domain.rb
+++ b/lib/acts_as_tenant/controller_extensions/subdomain_or_domain.rb
@@ -18,6 +18,10 @@ module ActsAsTenant
           tenant_class.where(tenant_second_column => request.domain.downcase).first
         end
       end
+
+      def current_tenant
+        ActsAsTenant.current_tenant
+      end
     end
   end
 end

--- a/spec/acts_as_tenant/tenant_by_filter_spec.rb
+++ b/spec/acts_as_tenant/tenant_by_filter_spec.rb
@@ -15,12 +15,14 @@ end
 describe ApplicationController2, type: :controller do
   controller do
     def index
-      render plain: "custom called"
+      # Exercise current_tenant helper method
+      render plain: current_tenant.name
     end
   end
 
   it "Finds the correct tenant using the filter command" do
     get :index
     expect(ActsAsTenant.current_tenant.name).to eq "account1"
+    expect(response.body).to eq "account1"
   end
 end

--- a/spec/acts_as_tenant/tenant_by_subdomain_or_domain_spec.rb
+++ b/spec/acts_as_tenant/tenant_by_subdomain_or_domain_spec.rb
@@ -6,11 +6,18 @@ class ApplicationController < ActionController::Base
 end
 
 describe ApplicationController, type: :controller do
-  let!(:account) { Account.create!(subdomain: "subdomain", domain: "example.com") }
+  let!(:account) do
+    Account.create!(
+      subdomain: "subdomain",
+      domain: "example.com",
+      name: "account1"
+    )
+  end
 
   controller(ApplicationController) do
     def index
-      render plain: "custom called"
+      # Exercise current_tenant helper method
+      render plain: current_tenant.name
     end
   end
 
@@ -18,12 +25,14 @@ describe ApplicationController, type: :controller do
     @request.host = "example.com"
     get :index
     expect(ActsAsTenant.current_tenant).to eq account
+    expect(response.body).to eq "account1"
   end
 
   it "Finds the correct tenant with a subdomain.example.com" do
     @request.host = "subdomain.example.com"
     get :index
     expect(ActsAsTenant.current_tenant).to eq account
+    expect(response.body).to eq "account1"
   end
 
   it "Finds the correct tenant with a www.subdomain.example.com" do

--- a/spec/acts_as_tenant/tenant_by_subdomain_spec.rb
+++ b/spec/acts_as_tenant/tenant_by_subdomain_spec.rb
@@ -6,11 +6,12 @@ class ApplicationController < ActionController::Base
 end
 
 describe ApplicationController, type: :controller do
-  let!(:account) { Account.create!(subdomain: "account1") }
+  let!(:account) { Account.create!(subdomain: "account1", name: "account1") }
 
   controller do
     def index
-      render plain: "custom called"
+      # Exercise current_tenant helper method
+      render plain: current_tenant.name
     end
   end
 
@@ -18,11 +19,13 @@ describe ApplicationController, type: :controller do
     @request.host = "account1.example.com"
     get :index
     expect(ActsAsTenant.current_tenant).to eq account
+    expect(response.body).to eq("account1")
   end
 
   it "Finds the correct tenant with a www.subdomain.example.com" do
     @request.host = "www.account1.example.com"
     get :index
     expect(ActsAsTenant.current_tenant).to eq account
+    expect(response.body).to eq("account1")
   end
 end


### PR DESCRIPTION
Calling `helper_method :inexistent_method` does not fail.

`current_tenant` needs to live alongside each module if we want to invoke them as helper methods as it doesn't reach out back to the parent module (`ActsAsTenant::ControllerExtensions`) that is including them.

This is currently broken in master and am unable to point my Gemfile to the fork.
We heavily depend on `current_tenant` helper method and I think other people do as well.

@excid3, I'm open to suggestions if you have any on how to test `current_tenant` as a helper method.

The other direction could be another module that is included in each controller concern, but I'm not sure it's all worth it. The repetition doesn't bother me much and I'm ok with that for the time being. 

